### PR TITLE
Support custom S3 endpoints such as MinIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,8 @@
 [![Go Report Card](https://goreportcard.com/badge/fclairamb/ftpserver)](https://goreportcard.com/report/fclairamb/ftpserver)
 [![GoDoc](https://godoc.org/github.com/fclairamb/ftpserver?status.svg)](https://godoc.org/github.com/fclairamb/ftpserver/server)
 
-This FTP server is a gateway between old-school FTP devices and modern cloud based file systems, using the 
+This FTP server is a gateway between old-school FTP devices and modern cloud based file systems, using the
 [afero](https://github.com/spf13/afero) 's Fs interface.
-
-
 
 At the current stage, supported FS are:
 - Local disk
@@ -80,10 +78,13 @@ Here is a sample config file:
       "pass": "s3",
       "fs": "s3",
       "params": {
+        "endpoint": "https://s3.amazonaws.com",
         "region": "eu-west-1",
         "bucket": "my-bucket",
         "access_key_id": "AKIA....",
         "secret_access_key": "IDxd...."
+        "disable_ssl": "false",
+        "path_style": "false"
       }
     },
     {
@@ -145,4 +146,3 @@ curl ftp://test:test@localhost:2121/kitty.jpg -o kitty2.jpg
 # Compare it
 diff kitty.jpg kitty2.jpg
 ```
-

--- a/fs/s3/s3.go
+++ b/fs/s3/s3.go
@@ -13,14 +13,18 @@ import (
 
 // LoadFs loads a file system from an access description
 func LoadFs(access *confpar.Access) (afero.Fs, error) {
+	endpoint := access.Params["endpoint"]
 	region := access.Params["region"]
 	bucket := access.Params["bucket"]
 	keyID := access.Params["access_key_id"]
 	secretAccessKey := access.Params["secret_access_key"]
 
 	sess, errSession := session.NewSession(&aws.Config{
-		Region:      &region,
-		Credentials: credentials.NewStaticCredentials(keyID, secretAccessKey, ""),
+		Endpoint:         aws.String(endpoint),
+		Region:           aws.String(region),
+		Credentials:      credentials.NewStaticCredentials(keyID, secretAccessKey, ""),
+		DisableSSL:       aws.Bool(access.Params["disable_ssl"] == "true"),
+		S3ForcePathStyle: aws.Bool(access.Params["path_style"] == "true"),
 	})
 
 	if errSession != nil {


### PR DESCRIPTION
Tested with https://play.min.io

```
{
  "version": 1,
  "accesses": [
    {
      "user": "test",
      "pass": "test",
      "fs": "s3",
      "params": {
        "endpoint": "https://play.min.io",
        "region": "us-east-1",
        "bucket": "testbucket",
        "access_key_id": "Q3AM3UQ867SPQQA43P2F",
        "secret_access_key": "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG",
        "path_style": "true"
      }
    }
  ],
  "passive_transfer_port_range": {
    "start": 2122,
    "end": 2130
  }
}
```