### PR TITLE
Make it possible to use default credential provider chain for Amazon S3

### DIFF
--- a/fs/s3/s3.go
+++ b/fs/s3/s3.go
@@ -25,7 +25,7 @@ func LoadFs(access *confpar.Access) (afero.Fs, error) {
 		S3ForcePathStyle: aws.Bool(access.Params["path_style"] == "true"),
 	}
 
-	if keyID != "" || secretAccessKey != "" {
+	if keyID != "" && secretAccessKey != "" {
 		conf.Credentials = credentials.NewStaticCredentials(keyID, secretAccessKey, "")
 	}
 

--- a/fs/s3/s3.go
+++ b/fs/s3/s3.go
@@ -19,13 +19,21 @@ func LoadFs(access *confpar.Access) (afero.Fs, error) {
 	keyID := access.Params["access_key_id"]
 	secretAccessKey := access.Params["secret_access_key"]
 
-	sess, errSession := session.NewSession(&aws.Config{
-		Endpoint:         aws.String(endpoint),
+	conf := aws.Config{
 		Region:           aws.String(region),
-		Credentials:      credentials.NewStaticCredentials(keyID, secretAccessKey, ""),
 		DisableSSL:       aws.Bool(access.Params["disable_ssl"] == "true"),
 		S3ForcePathStyle: aws.Bool(access.Params["path_style"] == "true"),
-	})
+	}
+
+	if keyID != "" || secretAccessKey != "" {
+		conf.Credentials = credentials.NewStaticCredentials(keyID, secretAccessKey, "")
+	}
+
+	if endpoint != "" {
+		conf.Endpoint = aws.String(endpoint)
+	}
+
+	sess, errSession := session.NewSession(&conf)
 
 	if errSession != nil {
 		return nil, errSession


### PR DESCRIPTION
Fixes #232 

I'm not much of a Go developer so let me know if I'm doing anything wrong. However this should allow people like me to just use the default credential provider chain rather than static creds in the JSON configuration file.

More info here:
https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html