### PR TITLE
feat: add Extensions configuration with EnableHASH support

### DIFF
--- a/config/confpar/confpar.go
+++ b/config/confpar/confpar.go
@@ -53,6 +53,11 @@ type ServerCert struct {
 	Key  string `json:"key"`  // Private key
 }
 
+// Extensions define the relevant configurations for extended features
+type Extensions struct {
+	EnableHASH bool `json:"enable_hash"` // Enable support for calculating hash value of files
+}
+
 // Content defines the content of the config file
 type Content struct {
 	Version                  int              `json:"version"`                     // File format version
@@ -62,6 +67,7 @@ type Content struct {
 	HashPlaintextPasswords   bool             `json:"hash_plaintext_passwords"`    // Overwrite plain-text passwords with hashed equivalents
 	Accesses                 []*Access        `json:"accesses"`                    // Accesses offered to users
 	PassiveTransferPortRange *PortRange       `json:"passive_transfer_port_range"` // Listen port range
+	Extensions               Extensions       `json:"extensions"`                  // Extended features
 	Logging                  Logging          `json:"logging"`                     // Logging parameters
 	TLS                      *TLS             `json:"tls"`                         // TLS Config
 	TLSRequired              string           `json:"tls_required"`

--- a/server/server.go
+++ b/server/server.go
@@ -95,6 +95,7 @@ func (s *Server) GetSettings() (*serverlib.Settings, error) {
 		PublicHost:               conf.PublicHost,
 		PassiveTransferPortRange: portRange,
 		TLSRequired:              tlsRequired,
+		EnableHASH:               conf.Extensions.EnableHASH,
 	}, nil
 }
 func (s *Server) ReloadConfig() error {


### PR DESCRIPTION
This PR implements extended configuration fields to enable the HASH feature in ftpserverlib.

## Changes
- Added Extensions struct to enable extended features configuration
- Added Extensions field to Content struct for configuration parsing
- Updated GetSettings() to include EnableHASH field from configuration

Fixes #1454

🤖 Generated with [Claude Code](https://claude.ai/code)