### PR TITLE
chore: keep pre-1.0 versioning on breaking changes

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "go",
+  "bump-minor-pre-major": true,
   "include-component-in-tag": false,
   "include-v-in-tag": true,
   "changelog-sections": [


### PR DESCRIPTION
Set release-please's `bump-minor-pre-major` so breaking changes (e.g. `fix(sftp)!`) bump the **minor** version within 0.x instead of jumping to **1.0.0**. Per semver, 0.x releases may carry breaking changes.

Without this, the pending release PR #1677 retargeted from `0.16.0` to `1.0.0` after the SFTP host-key fix (#1716) merged. Once this lands, release-please will recompute #1677 back to `0.16.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)